### PR TITLE
Fix file naming generation issue, length under 14 chars, based on datetime hash when hours, minutes or seconds match zero

### DIFF
--- a/src/history.controller.ts
+++ b/src/history.controller.ts
@@ -84,12 +84,12 @@ export default class HistoryController {
                     p: path.ParsedPath;
 
                 now = new Date();
+                now = new Date(now.getTime() - (now.getTimezoneOffset() * 60000));
+                now = now.toISOString().substring(0, 19).replace(/[-:T]/g, '');
                 p = path.parse(document.fileName);
                 revisionFile =  // toto_20151213215326.js
                         p.name+'_'+
-                        String(10000*now.getFullYear() + 100*(now.getMonth()+1) + now.getDate()) +
-                        (now.getHours() < 10 ? '0' : '') +
-                        String(10000*now.getHours() + 100*now.getMinutes() + now.getSeconds()) +
+                        now +
                         p.ext ;
 
                 revisionFile = path.join(


### PR DESCRIPTION
Depending on the current date/time filename generation might be under 14 characters, thus when [pattern](https://github.com/jcsmorais/local-history/blob/master/src/history.controller.ts#L46) is used to fetch history files, files with names under 14 characters are discarded thus not shown in file history panel.

Example of date/time that leads into this issue, given:

```
var now = new Date('2017/07/08 00:06:00');
```

when we run through the [file naming generation logic](https://github.com/jcsmorais/local-history/blob/master/src/history.controller.ts#L88) we'll end up with something like:

```
201707080600
```
where the time piece is wrongly represented by `0600`.

/cc @zabel-xyz 