### PR TITLE
replace activitybar raster icon with vector version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "viewsContainers": {
             "activitybar": [{
                 "id": "localHistory",
-                "icon": "resources/images/dark/history.png",
+                "icon": "resources/images/dark/history.svg",
                 "title": "Local history"
             }]
         },

--- a/resources/images/dark/history.svg
+++ b/resources/images/dark/history.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-50 -50 300 300" stroke="white" stroke-width="15" fill="none">
+    <path stroke-width="30" d="m35,50 a80 80 0 1 1 0,95" />
+    <path d="m 60,110 h40 v-60" />
+    <path d="m 15,70 v-50 l50,50 h-50" fill="white" stroke-linecap="square" stroke-linejoin="round" />
+</svg>


### PR DESCRIPTION
quick SVG rewrite of original icon to smooth the raster jaggedness 
Before: ![before](https://user-images.githubusercontent.com/1761395/42833553-ac24f0e4-89f4-11e8-98f7-a64e05a17943.png)  
After: ![after](https://user-images.githubusercontent.com/1761395/42833565-b678b5a8-89f4-11e8-9b9f-530ac2e35e66.png)

