### PR TITLE
Don't create new version if the document data wasn't changed from the last time it was saved

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,11 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     // Create history on save document
-    vscode.workspace.onDidSaveTextDocument(document => {
+    vscode.workspace.onDidSaveTextDocument(async (document) => {
+        if (await checkIfAlreadySaved(context, document)) {
+            return
+        }
+        
         controller.saveRevision(document)
             .then ((saveDocument) => {
                 // refresh viewer (if any)
@@ -62,3 +66,16 @@ export function activate(context: vscode.ExtensionContext) {
 
 // function deactivate() {
 // }
+
+async function checkIfAlreadySaved(context, document) {
+    let fileName = document.fileName
+    let currentData = await context.workspaceState.get(fileName)
+    let data = document.getText()
+    let check = currentData && currentData == data
+
+    if (!check) {
+        await context.workspaceState.update(fileName, data)
+    }
+
+    return check
+}


### PR DESCRIPTION
away to not create new revisions if the document data wasnt changed from the last time it was saved

not exactly as https://github.com/zabel-xyz/local-history/issues/93 but this is kinda faster than 
- doing the file lockup
- opening it to get its content
- do the comparison