### PR TITLE
Deal with settings defaults correctly

### DIFF
--- a/src/history.settings.ts
+++ b/src/history.settings.ts
@@ -180,11 +180,11 @@ export class HistorySettings {
 
         return {
             folder: workspacefolder,
-            daysLimit: <number>config.get('daysLimit') || 30,
-            saveDelay: <number>config.get('saveDelay') || 0,
-            maxDisplay: <number>config.get('maxDisplay') || 10,
-            dateLocale: <string>config.get('dateLocale') || undefined,
-            exclude: <string[]>config.get('exclude') || ['**/.history/**','**/.vscode/**','**/node_modules/**','**/typings/**','**/out/**'],
+            daysLimit: <number>config.get('daysLimit', 30),
+            saveDelay: <number>config.get('saveDelay', 0),
+            maxDisplay: <number>config.get('maxDisplay', 10),
+            dateLocale: <string>config.get('dateLocale', undefined),
+            exclude: <string[]>config.get('exclude', ['**/.history/**','**/.vscode/**','**/node_modules/**','**/typings/**','**/out/**']),
             enabled: historyPath != null && historyPath !== '',
             historyPath: historyPath,
             absolute: absolute


### PR DESCRIPTION
Hi!

Have an issue similar to #83, #90. Setting `"local-history.saveDelay": 0` doesn't have any effect and local-history purges all old versions.

I believe the issue might with incorrect using of `||` syntax for settings default. Note, that `0 || 30` evaluates to 30 (not 0).

According to https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration.get `get` method has a second parameter for the default vaule, so it should be utilized.

**WARNING: I did not test this code**.